### PR TITLE
Small fix for unitExists

### DIFF
--- a/src/ConversionRepository.php
+++ b/src/ConversionRepository.php
@@ -77,7 +77,7 @@ final class ConversionRepository
             throw new ConvertorException("Base Unit Does Not Exist");
         }
 
-        $this->definitions[] = $definition;
+        $this->definitions[$definition->getUnit()] = $definition;
     }
 
     public function removeConversion(string $unit): void


### PR DESCRIPTION
When adding a new unit via addUnit, the unitExists method won't recognise it. This is because the named array key does not exist.