### PR TITLE
Allow PHP ^8.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2"


### PR DESCRIPTION
The package seems to be working fine with PHP 8, so I added the version to composer.json.